### PR TITLE
Update 11 - Use HTTPS instead of HTTP

### DIFF
--- a/src/services/photoshoots.js
+++ b/src/services/photoshoots.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const photoshootsApi = axios.create({
-    baseURL: "http://photografinder.xyz/photoshoots/"
+    baseURL: "https://photografinder.xyz/photoshoots/"
 });
 
 // POST

--- a/src/services/posts.js
+++ b/src/services/posts.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const postsApi = axios.create({
-    baseURL: "http://photografinder.xyz/posts/"
+    baseURL: "https://photografinder.xyz/posts/"
 });
 
 // POST

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const usersApi = axios.create({
-    baseURL: "http://photografinder.xyz/users/"
+    baseURL: "https://photografinder.xyz/users/"
 });
 
 


### PR DESCRIPTION
- Cloudflare can access the backend API since it now uses SSL